### PR TITLE
readme: fix the layout:include example

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Content.html
   ...
 
   <div layout:include="Modal2.html :: modal" th:with="modalId='message', modalHeader='Message'" th:remove="tag">
-    <p th:fragment="modal-content">Message goes here!</p>
+    <p layout:fragment="modal-content">Message goes here!</p>
   </div>
 
   ...


### PR DESCRIPTION
When I copy-pasted this example as-is into an app to try it out, it didn’t work.
Instead of showing “Message goes here!”, it was showing “My modal content”.
Based on the comments in ticket #5 and my own testing, I believe that this
should have been layout:fragment rather than th:fragment.
