### PR TITLE
Cannot use th:text in content template

### DIFF
--- a/Tests/nz/net/ultraq/thymeleaf/tests/decorator/DecoratorTester.java
+++ b/Tests/nz/net/ultraq/thymeleaf/tests/decorator/DecoratorTester.java
@@ -240,4 +240,14 @@ public class DecoratorTester extends AbstractLayoutDialectTester {
 
 		testOK("decorator/FragmentProcessorMerging");
 	}
+
+	/**
+	 * Test the use of "th:text" in the title tag of a page decorated
+	 * with a layout.
+	 */
+	@Test
+	public void noTitleDecoration() {
+
+		testOK("decorator/HeadDecorationThText");
+	}
 }

--- a/Tests/nz/net/ultraq/thymeleaf/tests/decorator/HeadDecorationThText.thtest
+++ b/Tests/nz/net/ultraq/thymeleaf/tests/decorator/HeadDecorationThText.thtest
@@ -1,0 +1,43 @@
+%TEMPLATE_MODE HTML5
+
+%INPUT
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorator="Layout">
+	<head>
+		<title th:text="'Content title'">Placeholder title</title>
+	</head>
+	<body>
+		<section layout:fragment="content">
+			<p>This is a paragraph from the content page</p>
+		</section>
+	</body>
+</html>
+
+%INPUT[Layout]
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+	<head>
+		<title>Layout title</title>
+	</head>
+	<body>
+		<section layout:fragment="content">
+			<p>Page content goes here</p>
+		</section>
+	</body>
+</html>
+
+%OUTPUT
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title>Content title</title>
+	</head>
+	<body>
+		<section>
+			<p>This is a paragraph from the content page</p>
+		</section>
+	</body>
+</html>


### PR DESCRIPTION
HTMLHeadDecorator prevents from using a "th:text" in the
content template.
Added a test case to demonstrate that.
Note that the same test case works when using th:utext.
