### PR TITLE
Fixed insertion of headers at the end

### DIFF
--- a/Source/nz/net/ultraq/thymeleaf/decorator/HtmlHeadDecorator.java
+++ b/Source/nz/net/ultraq/thymeleaf/decorator/HtmlHeadDecorator.java
@@ -103,11 +103,15 @@ public class HtmlHeadDecorator extends XmlElementDecorator {
 		if (contenthead != null) {
 			for (Element contentheadelement: contenthead.getElementChildren()) {
 				int insertionpoint = findBestInsertionPoint(decoratorhead, contentheadelement);
-				Node whitespace = decoratorhead.getChildren().get(insertionpoint);
-				if (whitespace instanceof Text) {
-					decoratorhead.insertChild(insertionpoint, whitespace.cloneNode(null, false));
+				if (insertionpoint < decoratorhead.getChildren().size()) {
+	            Node whitespace = decoratorhead.getChildren().get(insertionpoint);
+	            if (whitespace instanceof Text) {
+	               decoratorhead.insertChild(insertionpoint, whitespace.cloneNode(null, false));
+	            }
+	            decoratorhead.insertChild(insertionpoint + 1, contentheadelement);
+				} else {
+               decoratorhead.insertChild(insertionpoint, contentheadelement);
 				}
-				decoratorhead.insertChild(insertionpoint + 1, contentheadelement);
 			}
 		}
 		if (resultingtitle != null) {


### PR DESCRIPTION
When using header element types in a page which are not present in the header of the layout template, the merging of the headers results in an ArrayIndexOutOfBoundException. This patch fixes that and inserts "new" header element types to the end of the header.
