### PR TITLE
Added support for multiple fragments definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /Classes
 /node_modules
 npm-debug.log
+bin
 
 # IDEs
 /.idea

--- a/source/nz/net/ultraq/thymeleaf/LayoutDialect.groovy
+++ b/source/nz/net/ultraq/thymeleaf/LayoutDialect.groovy
@@ -16,12 +16,18 @@
 
 package nz.net.ultraq.thymeleaf
 
+import org.thymeleaf.dialect.AbstractProcessorDialect
+import org.thymeleaf.processor.IProcessor
+import org.thymeleaf.standard.processor.StandardXmlNsTagProcessor
+import org.thymeleaf.templatemode.TemplateMode
+
 import nz.net.ultraq.thymeleaf.context.extensions.IContextExtensions
 import nz.net.ultraq.thymeleaf.decorators.DecorateProcessor
 import nz.net.ultraq.thymeleaf.decorators.DecoratorProcessor
 import nz.net.ultraq.thymeleaf.decorators.SortingStrategy
 import nz.net.ultraq.thymeleaf.decorators.TitlePatternProcessor
 import nz.net.ultraq.thymeleaf.decorators.strategies.AppendingStrategy
+import nz.net.ultraq.thymeleaf.fragments.CollectFragmentProcessor
 import nz.net.ultraq.thymeleaf.fragments.FragmentProcessor
 import nz.net.ultraq.thymeleaf.includes.IncludeProcessor
 import nz.net.ultraq.thymeleaf.includes.InsertProcessor
@@ -34,11 +40,6 @@ import nz.net.ultraq.thymeleaf.models.extensions.IStandaloneElementTagExtensions
 import nz.net.ultraq.thymeleaf.models.extensions.ITemplateEventExtensions
 import nz.net.ultraq.thymeleaf.models.extensions.ITextExtensions
 import nz.net.ultraq.thymeleaf.models.extensions.TemplateModelExtensions
-
-import org.thymeleaf.dialect.AbstractProcessorDialect
-import org.thymeleaf.processor.IProcessor
-import org.thymeleaf.standard.processor.StandardXmlNsTagProcessor
-import org.thymeleaf.templatemode.TemplateMode
 
 /**
  * A dialect for Thymeleaf that lets you build layouts and reusable templates in
@@ -104,6 +105,7 @@ class LayoutDialect extends AbstractProcessorDialect {
 			new InsertProcessor(TemplateMode.HTML, dialectPrefix),
 			new ReplaceProcessor(TemplateMode.HTML, dialectPrefix),
 			new FragmentProcessor(TemplateMode.HTML, dialectPrefix),
+			new CollectFragmentProcessor(TemplateMode.HTML, dialectPrefix),
 			new TitlePatternProcessor(TemplateMode.HTML, dialectPrefix),
 
 			// Processors available in the XML template mode
@@ -113,7 +115,8 @@ class LayoutDialect extends AbstractProcessorDialect {
 			new IncludeProcessor(TemplateMode.XML, dialectPrefix),
 			new InsertProcessor(TemplateMode.XML, dialectPrefix),
 			new ReplaceProcessor(TemplateMode.XML, dialectPrefix),
-			new FragmentProcessor(TemplateMode.XML, dialectPrefix)
+			new FragmentProcessor(TemplateMode.XML, dialectPrefix),
+			new CollectFragmentProcessor(TemplateMode.XML, dialectPrefix)
 		]
 	}
 }

--- a/source/nz/net/ultraq/thymeleaf/fragments/CollectFragmentProcessor.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/CollectFragmentProcessor.groovy
@@ -87,30 +87,30 @@ class CollectFragmentProcessor extends AbstractAttributeTagProcessor {
 		// Replace the tag body with the fragment
 		if (fragments) {
 			def modelFactory = context.modelFactory
-			def merger = new ElementMerger(context);
-			def replacementModel = modelFactory.createModel(tag);
-			def first = true;
-			fragments.each{
+			def merger = new ElementMerger(context)
+			def replacementModel = modelFactory.createModel(tag)
+			def first = true
+			fragments.each {
 				fragment ->
 				if (first) {
-					replacementModel = merger.merge(replacementModel, fragment);
-					first = false;
+					replacementModel = merger.merge(replacementModel, fragment)
+					first = false
 				} else {
-					def firstEvent = true;
-					fragment.each{
+					def firstEvent = true
+					fragment.each {
 						event ->
 						if (firstEvent) {
-							firstEvent = false;
-							replacementModel.add(new Text("\n"));
+							firstEvent = false
+							replacementModel.add(new Text('\n'))
 							replacementModel.add(modelFactory.removeAttribute(event,
-								dialectPrefix, PROCESSOR_DEFINE));
+								dialectPrefix, PROCESSOR_DEFINE))
 						} else {
-							replacementModel.add(event);
+							replacementModel.add(event)
 						}
-					};
+					}
 
 				}
-			};
+			}
 
 			// Remove the layout:fragment attribute - Thymeleaf won't do it for us
 			// when using StructureHandler.replaceWith(...)

--- a/source/nz/net/ultraq/thymeleaf/fragments/CollectFragmentProcessor.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/CollectFragmentProcessor.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2012, Emanuel Rabina (http://www.ultraq.net.nz/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nz.net.ultraq.thymeleaf.fragments
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.thymeleaf.context.ITemplateContext
+import org.thymeleaf.engine.AttributeName
+import org.thymeleaf.engine.Text
+import org.thymeleaf.model.IProcessableElementTag
+import org.thymeleaf.processor.element.AbstractAttributeTagProcessor
+import org.thymeleaf.processor.element.IElementTagStructureHandler
+import org.thymeleaf.templatemode.TemplateMode
+
+import nz.net.ultraq.thymeleaf.models.ElementMerger
+
+/**
+ * This processor serves a dual purpose: to mark sections of the template that
+ * can be replaced, and to do the replacing when they're encountered.
+ *
+ * @author Emanuel Rabina
+ */
+class CollectFragmentProcessor extends AbstractAttributeTagProcessor {
+
+	private static final Logger logger = LoggerFactory.getLogger(CollectFragmentProcessor)
+
+	private static boolean warned = false
+
+	static final String PROCESSOR_DEFINE = 'define'
+	static final String PROCESSOR_COLLECT = 'collect'
+	static final int PROCESSOR_PRECEDENCE = 1
+
+	/**
+	 * Constructor, sets this processor to work on the 'fragment' attribute.
+	 *
+	 * @param templateMode
+	 * @param dialectPrefix
+	 */
+	CollectFragmentProcessor(TemplateMode templateMode, String dialectPrefix) {
+
+		super(templateMode, dialectPrefix, null, false, PROCESSOR_COLLECT, true, PROCESSOR_PRECEDENCE, true)
+	}
+
+	/**
+	 * Inserts the content of fragments into the encountered fragment placeholder.
+	 *
+	 * @param context
+	 * @param model
+	 * @param attributeName
+	 * @param attributeValue
+	 * @param structureHandler
+	 */
+	@Override
+	@SuppressWarnings('AssignmentToStaticFieldFromInstanceMethod')
+	protected void doProcess(ITemplateContext context, IProcessableElementTag tag,
+		AttributeName attributeName, String attributeValue, IElementTagStructureHandler structureHandler) {
+
+		// Emit a warning if found in the <head> section
+		if (templateMode == TemplateMode.HTML &&
+		    context.elementStack.any { element -> element.elementCompleteName == 'head' }) {
+			if (!warned) {
+				logger.warn(
+					'You don\'t need to put the layout:fragment/data-layout-fragment attribute into the <head> section - ' +
+					'the decoration process will automatically copy the <head> section of your content templates into your layout page.'
+				)
+				warned = true
+			}
+		}
+
+		// Locate the fragment that corresponds to this decorator/include fragment
+		def fragments = FragmentMap.get(context)[(attributeValue)]
+
+		// Replace the tag body with the fragment
+		if (fragments) {
+			def modelFactory = context.modelFactory
+			def merger = new ElementMerger(context);
+			def replacementModel = modelFactory.createModel(tag);
+			def first = true;
+			fragments.each{
+				fragment ->
+				if (first) {
+					replacementModel = merger.merge(replacementModel, fragment);
+					first = false;
+				} else {
+					def firstEvent = true;
+					fragment.each{
+						event ->
+						if (firstEvent) {
+							firstEvent = false;
+							replacementModel.add(new Text("\n"));
+							replacementModel.add(modelFactory.removeAttribute(event,
+								dialectPrefix, PROCESSOR_DEFINE));
+						} else {
+							replacementModel.add(event);
+						}
+					};
+
+				}
+			};
+
+			// Remove the layout:fragment attribute - Thymeleaf won't do it for us
+			// when using StructureHandler.replaceWith(...)
+			replacementModel.replace(0, modelFactory.removeAttribute(replacementModel.first(),
+				dialectPrefix, PROCESSOR_COLLECT))
+
+			structureHandler.replaceWith(replacementModel, true)
+		}
+	}
+}

--- a/source/nz/net/ultraq/thymeleaf/fragments/FragmentFinder.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/FragmentFinder.groovy
@@ -56,13 +56,11 @@ class FragmentFinder {
 		while (eventIndex < model.size()) {
 			def event = model.get(eventIndex)
 			if (event instanceof IOpenElementTag) {
-				def fragmentName = event.getAttributeValue(dialectPrefix, FragmentProcessor.PROCESSOR_NAME) ?:
+				def fragmentName = event.getAttributeValue(dialectPrefix, FragmentProcessor.PROCESSOR_NAME) ?: 
 					event.getAttributeValue(dialectPrefix, CollectFragmentProcessor.PROCESSOR_DEFINE)
 				if (fragmentName) {
 					def fragment = model.getModel(eventIndex)
-					if (!fragmentsMap[fragmentName]) {
-						fragmentsMap[fragmentName] = [];
-					}
+					fragmentsMap[fragmentName] = fragmentsMap[fragmentName] ?: []
 					fragmentsMap[fragmentName] << fragment
 					eventIndex += fragment.size()
 					continue

--- a/source/nz/net/ultraq/thymeleaf/fragments/FragmentFinder.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/FragmentFinder.groovy
@@ -56,14 +56,21 @@ class FragmentFinder {
 		while (eventIndex < model.size()) {
 			def event = model.get(eventIndex)
 			if (event instanceof IOpenElementTag) {
-				def fragmentName = event.getAttributeValue(dialectPrefix, FragmentProcessor.PROCESSOR_NAME) ?: 
-					event.getAttributeValue(dialectPrefix, CollectFragmentProcessor.PROCESSOR_DEFINE)
+				def fragmentName = event.getAttributeValue(dialectPrefix, FragmentProcessor.PROCESSOR_NAME)
+				def collect = false
+				if (!fragmentName) {
+					collect = true
+					fragmentName = event.getAttributeValue(dialectPrefix, CollectFragmentProcessor.PROCESSOR_DEFINE) ?: 
+						event.getAttributeValue(dialectPrefix, CollectFragmentProcessor.PROCESSOR_COLLECT)
+				}
 				if (fragmentName) {
 					def fragment = model.getModel(eventIndex)
-					fragmentsMap[fragmentName] = fragmentsMap[fragmentName] ?: []
+					fragmentsMap[fragmentName] = fragmentsMap[fragmentName] ?: [] as Queue
 					fragmentsMap[fragmentName] << fragment
-					eventIndex += fragment.size()
-					continue
+					if (!collect) {
+						eventIndex += fragment.size()
+						continue
+					}
 				}
 			}
 			eventIndex++

--- a/source/nz/net/ultraq/thymeleaf/fragments/FragmentFinder.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/FragmentFinder.groovy
@@ -50,16 +50,20 @@ class FragmentFinder {
 	 */
 	Map<String,IModel> findFragments(IModel model) {
 
-		def fragments = [:]
+		def fragmentsMap = [:]
 
 		def eventIndex = 0
 		while (eventIndex < model.size()) {
 			def event = model.get(eventIndex)
 			if (event instanceof IOpenElementTag) {
-				def fragmentName = event.getAttributeValue(dialectPrefix, FragmentProcessor.PROCESSOR_NAME)
+				def fragmentName = event.getAttributeValue(dialectPrefix, FragmentProcessor.PROCESSOR_NAME) ?:
+					event.getAttributeValue(dialectPrefix, CollectFragmentProcessor.PROCESSOR_DEFINE)
 				if (fragmentName) {
 					def fragment = model.getModel(eventIndex)
-					fragments << [(fragmentName): fragment]
+					if (!fragmentsMap[fragmentName]) {
+						fragmentsMap[fragmentName] = [];
+					}
+					fragmentsMap[fragmentName] << fragment
 					eventIndex += fragment.size()
 					continue
 				}
@@ -67,6 +71,6 @@ class FragmentFinder {
 			eventIndex++
 		}
 
-		return fragments
+		return fragmentsMap
 	}
 }

--- a/source/nz/net/ultraq/thymeleaf/fragments/FragmentMap.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/FragmentMap.groovy
@@ -52,8 +52,9 @@ class FragmentMap extends HashMap<String,IModel> {
 	 */
 	static void setForNode(IContext context, IElementModelStructureHandler structureHandler,
 		Map<String,List> fragments) {
-		def res = get(context);
-		fragments.each{
+		def res = fragments;
+		def appned = get(context);
+		appned.each{
 			k, v ->
 			if (res[k]) {
 				res[k] += v;

--- a/source/nz/net/ultraq/thymeleaf/fragments/FragmentMap.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/FragmentMap.groovy
@@ -52,16 +52,16 @@ class FragmentMap extends HashMap<String,IModel> {
 	 */
 	static void setForNode(IContext context, IElementModelStructureHandler structureHandler,
 		Map<String,List> fragments) {
-		def res = fragments;
-		def appned = get(context);
-		appned.each{
+		def res = fragments
+		def appned = get(context)
+		appned.each {
 			k, v ->
 			if (res[k]) {
-				res[k] += v;
-			}else{
-				res[k] = v;
+				res[k] += v
+			} else {
+				res[k] = v
 			}
-		};
+		}
 		structureHandler.setLocalVariable(FRAGMENT_COLLECTION_KEY, res)
 	}
 }

--- a/source/nz/net/ultraq/thymeleaf/fragments/FragmentMap.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/FragmentMap.groovy
@@ -51,8 +51,16 @@ class FragmentMap extends HashMap<String,IModel> {
 	 * @param fragments The new fragments to add to the map.
 	 */
 	static void setForNode(IContext context, IElementModelStructureHandler structureHandler,
-		Map<String,IModel> fragments) {
-
-		structureHandler.setLocalVariable(FRAGMENT_COLLECTION_KEY, get(context) + fragments)
+		Map<String,List> fragments) {
+		def res = get(context);
+		fragments.each{
+			k, v ->
+			if (res[k]) {
+				res[k] += v;
+			}else{
+				res[k] = v;
+			}
+		};
+		structureHandler.setLocalVariable(FRAGMENT_COLLECTION_KEY, res)
 	}
 }

--- a/source/nz/net/ultraq/thymeleaf/fragments/FragmentProcessor.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/FragmentProcessor.groovy
@@ -16,8 +16,6 @@
 
 package nz.net.ultraq.thymeleaf.fragments
 
-import nz.net.ultraq.thymeleaf.models.ElementMerger
-
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.thymeleaf.context.ITemplateContext
@@ -26,6 +24,8 @@ import org.thymeleaf.model.IProcessableElementTag
 import org.thymeleaf.processor.element.AbstractAttributeTagProcessor
 import org.thymeleaf.processor.element.IElementTagStructureHandler
 import org.thymeleaf.templatemode.TemplateMode
+
+import nz.net.ultraq.thymeleaf.models.ElementMerger
 
 /**
  * This processor serves a dual purpose: to mark sections of the template that
@@ -80,10 +80,11 @@ class FragmentProcessor extends AbstractAttributeTagProcessor {
 		}
 
 		// Locate the fragment that corresponds to this decorator/include fragment
-		def fragment = FragmentMap.get(context)[(attributeValue)]
+		def fragments = FragmentMap.get(context)[(attributeValue)]
 
 		// Replace the tag body with the fragment
-		if (fragment) {
+		if (fragments) {
+			def fragment = fragments[fragments.size() - 1];
 			def modelFactory = context.modelFactory
 			def replacementModel = new ElementMerger(context).merge(modelFactory.createModel(tag), fragment)
 

--- a/source/nz/net/ultraq/thymeleaf/fragments/FragmentProcessor.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/FragmentProcessor.groovy
@@ -84,7 +84,7 @@ class FragmentProcessor extends AbstractAttributeTagProcessor {
 
 		// Replace the tag body with the fragment
 		if (fragments) {
-			def fragment = fragments[fragments.size() - 1];
+			def fragment = fragments[-1]
 			def modelFactory = context.modelFactory
 			def replacementModel = new ElementMerger(context).merge(modelFactory.createModel(tag), fragment)
 

--- a/source/nz/net/ultraq/thymeleaf/models/AttributeMerger.groovy
+++ b/source/nz/net/ultraq/thymeleaf/models/AttributeMerger.groovy
@@ -16,13 +16,14 @@
 
 package nz.net.ultraq.thymeleaf.models
 
-import nz.net.ultraq.thymeleaf.LayoutDialect
-import nz.net.ultraq.thymeleaf.fragments.FragmentProcessor
-
 import org.thymeleaf.context.ITemplateContext
 import org.thymeleaf.model.IModel
 import org.thymeleaf.standard.StandardDialect
 import org.thymeleaf.standard.processor.StandardWithTagProcessor
+
+import nz.net.ultraq.thymeleaf.LayoutDialect
+import nz.net.ultraq.thymeleaf.fragments.CollectFragmentProcessor
+import nz.net.ultraq.thymeleaf.fragments.FragmentProcessor
 
 /**
  * Merges attributes from one element into another.

--- a/source/nz/net/ultraq/thymeleaf/models/AttributeMerger.groovy
+++ b/source/nz/net/ultraq/thymeleaf/models/AttributeMerger.groovy
@@ -72,7 +72,8 @@ class AttributeMerger implements ModelMerger {
 
 			// Don't include layout:fragment processors
 			.findAll { sourceAttribute ->
-				return !sourceAttribute.equalsName(layoutDialectPrefix, FragmentProcessor.PROCESSOR_NAME)
+				return !sourceAttribute.equalsName(layoutDialectPrefix, FragmentProcessor.PROCESSOR_NAME) &&
+					!sourceAttribute.equalsName(layoutDialectPrefix, CollectFragmentProcessor.PROCESSOR_DEFINE)
 			}
 
 			.each { sourceAttribute ->

--- a/tests/nz/net/ultraq/thymeleaf/tests/decorators/xml/Document-XmlDecoration-MultipleElements-Nested.thtest
+++ b/tests/nz/net/ultraq/thymeleaf/tests/decorators/xml/Document-XmlDecoration-MultipleElements-Nested.thtest
@@ -44,12 +44,12 @@
 <root xmlns="http://www.example.org/">
 	<list>
 		<item>
-			<name>Tomatoes</name>
-			<price>3.99</price>
-		</item>
-		<item>
 			<name>Apples</name>
 			<price>2.75</price>
+		</item>
+		<item>
+			<name>Tomatoes</name>
+			<price>3.99</price>
 		</item>
 		<item>
 			<name>Potatoes</name>

--- a/tests/nz/net/ultraq/thymeleaf/tests/decorators/xml/Document-XmlDecoration-MultipleElements-Nested.thtest
+++ b/tests/nz/net/ultraq/thymeleaf/tests/decorators/xml/Document-XmlDecoration-MultipleElements-Nested.thtest
@@ -1,0 +1,59 @@
+
+# Test that standard decoration can occur on XML documents.
+
+%TEMPLATE_MODE XML
+
+
+%INPUT
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorate="~{Layout}">
+	<item layout:define="item">
+		<name>Tomatoes</name>
+		<price>3.99</price>
+	</item>
+</root>
+
+%INPUT[Layout]
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorate="~{Common}">
+	<item layout:define="item">
+		<name>Apples</name>
+		<price>2.75</price>
+	</item>
+</root>
+
+%INPUT[Common]
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+	<list>
+		<item layout:collect="item"></item>
+		<item>
+			<name>Potatoes</name>
+			<price>4.99</price>
+		</item>
+	</list>
+</root>
+
+%OUTPUT
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/">
+	<list>
+		<item>
+			<name>Tomatoes</name>
+			<price>3.99</price>
+		</item>
+		<item>
+			<name>Apples</name>
+			<price>2.75</price>
+		</item>
+		<item>
+			<name>Potatoes</name>
+			<price>4.99</price>
+		</item>
+	</list>
+</root>

--- a/tests/nz/net/ultraq/thymeleaf/tests/decorators/xml/Document-XmlDecoration-MultipleElements.thtest
+++ b/tests/nz/net/ultraq/thymeleaf/tests/decorators/xml/Document-XmlDecoration-MultipleElements.thtest
@@ -1,0 +1,54 @@
+
+# Test that standard decoration can occur on XML documents.
+
+%TEMPLATE_MODE XML
+
+
+%INPUT
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorate="~{Layout}">
+	<item layout:define="item">
+		<name>Tomatoes</name>
+		<price>3.99</price>
+	</item>
+	<item layout:define="item">
+		<name>Apples</name>
+		<price>2.75</price>
+	</item>
+</root>
+
+
+%INPUT[Layout]
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+	<list>
+		<item layout:collect="item"></item>
+		<item>
+			<name>Potatoes</name>
+			<price>4.99</price>
+		</item>
+	</list>
+</root>
+
+
+%OUTPUT
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/">
+	<list>
+		<item>
+			<name>Tomatoes</name>
+			<price>3.99</price>
+		</item>
+		<item>
+			<name>Apples</name>
+			<price>2.75</price>
+		</item>
+		<item>
+			<name>Potatoes</name>
+			<price>4.99</price>
+		</item>
+	</list>
+</root>

--- a/tests/nz/net/ultraq/thymeleaf/tests/decorators/xml/Document-XmlDecoration-NestedSameName.thtest
+++ b/tests/nz/net/ultraq/thymeleaf/tests/decorators/xml/Document-XmlDecoration-NestedSameName.thtest
@@ -1,0 +1,57 @@
+# Test that standard decoration can occur on XML documents.
+
+%TEMPLATE_MODE XML
+
+
+%INPUT
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorate="~{Layout}">
+	<item layout:define="item">
+		<name>Tomatoes</name>
+		<price>3.99</price>
+	</item>
+</root>
+
+%INPUT[Layout]
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorate="~{Common}">
+	<b layout:define="item">
+		<item layout:collect="item">
+		</item>
+	</b>
+</root>
+
+%INPUT[Common]
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+	<list>
+		<item layout:collect="item"></item>
+		<item>
+			<name>Potatoes</name>
+			<price>4.99</price>
+		</item>
+	</list>
+</root>
+
+%OUTPUT
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="http://www.example.org/">
+	<list>
+		<b>
+			<item>
+				<name>Tomatoes</name>
+				<price>3.99</price>
+			</item>
+		</b>
+		<item>
+			<name>Potatoes</name>
+			<price>4.99</price>
+		</item>
+	</list>
+</root>
+


### PR DESCRIPTION
I've separated processor names to avoid ambiguity for cases with nesting. To retain backward compatibility I left "fragment" processor and created separate "define" and "collect" processors.