### PR TITLE
fix #200: redeclaration of layout fragments in nested decoration hierarchies must produce the expected result

### DIFF
--- a/source/nz/net/ultraq/thymeleaf/fragments/FragmentMap.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/FragmentMap.groovy
@@ -45,6 +45,8 @@ class FragmentMap extends HashMap<String,List<IModel>> {
 	/**
 	 * Set the fragment collection to contain whatever it initially had, plus the
 	 * given fragments, just for the scope of the current node.
+	 *
+	 * This must be used when processing non include/insert/replace related directives.
 	 * 
 	 * @param context
 	 * @param structureHandler
@@ -52,11 +54,34 @@ class FragmentMap extends HashMap<String,List<IModel>> {
 	 */
 	static void setForNode(IContext context, IElementModelStructureHandler structureHandler,
 		Map<String,List<IModel>> fragments) {
+		setForNodeInternal(context, structureHandler, fragments, false)
+	}
+
+	/**
+	 * Set the fragment collection to contain whatever it initially had, plus the
+	 * given fragments, just for the scope of the current node.
+	 *
+	 * This must be used when processing include/insert/replace related directives.
+	 *
+	 * @param context
+	 * @param structureHandler
+	 * @param fragments The new fragments to add to the map.
+	 */
+	static void setForNodeIncludeProcessing(IContext context, IElementModelStructureHandler structureHandler,
+		Map<String,List<IModel>> fragments) {
+		setForNodeInternal(context, structureHandler, fragments, true)
+	}
+
+	private static void setForNodeInternal(IContext context, IElementModelStructureHandler structureHandler,
+		Map<String,List<IModel>> fragments, boolean isIncludeProcessing) {
 
 		structureHandler.setLocalVariable(FRAGMENT_COLLECTION_KEY,
 			get(context).inject(fragments.clone()) { accumulator, fragmentName, fragmentList ->
 				if (accumulator[fragmentName]) {
 					accumulator[fragmentName] += fragmentList
+					if (isIncludeProcessing) {
+						accumulator[fragmentName] = ((List) accumulator[fragmentName]).reverse()
+					}
 				}
 				else {
 					accumulator[fragmentName] = fragmentList

--- a/source/nz/net/ultraq/thymeleaf/fragments/FragmentProcessor.groovy
+++ b/source/nz/net/ultraq/thymeleaf/fragments/FragmentProcessor.groovy
@@ -84,7 +84,7 @@ class FragmentProcessor extends AbstractAttributeTagProcessor {
 
 		// Replace the tag body with the fragment
 		if (fragments) {
-			def fragment = fragments.first()
+			def fragment = fragments.size() == 1 ? fragments.first() : fragments.last()
 			def modelFactory = context.modelFactory
 			def replacementModel = new ElementMerger(context).merge(modelFactory.createModel(tag), fragment)
 

--- a/source/nz/net/ultraq/thymeleaf/includes/IncludeProcessor.groovy
+++ b/source/nz/net/ultraq/thymeleaf/includes/IncludeProcessor.groovy
@@ -91,7 +91,7 @@ class IncludeProcessor extends AbstractAttributeModelProcessor {
 
 		// Gather all fragment parts within the include element, scoping them to this element
 		def includeFragments = new FragmentFinder(dialectPrefix).findFragments(model)
-		FragmentMap.setForNode(context, structureHandler, includeFragments)
+		FragmentMap.setForNodeIncludeProcessing(context, structureHandler, includeFragments)
 
 		// Keep track of what template is being processed?  Thymeleaf does this for
 		// its include processor, so I'm just doing the same here.

--- a/source/nz/net/ultraq/thymeleaf/includes/InsertProcessor.groovy
+++ b/source/nz/net/ultraq/thymeleaf/includes/InsertProcessor.groovy
@@ -72,7 +72,7 @@ class InsertProcessor extends AbstractAttributeModelProcessor {
 
 		// Gather all fragment parts within this element, scoping them to this element
 		def includeFragments = new FragmentFinder(dialectPrefix).findFragments(model)
-		FragmentMap.setForNode(context, structureHandler, includeFragments)
+		FragmentMap.setForNodeIncludeProcessing(context, structureHandler, includeFragments)
 
 		// Keep track of what template is being processed?  Thymeleaf does this for
 		// its include processor, so I'm just doing the same here.

--- a/source/nz/net/ultraq/thymeleaf/includes/ReplaceProcessor.groovy
+++ b/source/nz/net/ultraq/thymeleaf/includes/ReplaceProcessor.groovy
@@ -72,7 +72,7 @@ class ReplaceProcessor extends AbstractAttributeModelProcessor {
 
 		// Gather all fragment parts within the include element, scoping them to this element
 		def includeFragments = new FragmentFinder(dialectPrefix).findFragments(model)
-		FragmentMap.setForNode(context, structureHandler, includeFragments)
+		FragmentMap.setForNodeIncludeProcessing(context, structureHandler, includeFragments)
 
 		// Keep track of what template is being processed?  Thymeleaf does this for
 		// its include processor, so I'm just doing the same here.

--- a/tests/nz/net/ultraq/thymeleaf/tests/decorators/Decorate-DeepHierarchy2.thtest
+++ b/tests/nz/net/ultraq/thymeleaf/tests/decorators/Decorate-DeepHierarchy2.thtest
@@ -1,0 +1,89 @@
+
+# Test a deep layout hierarchy (3 levels).
+
+%TEMPLATE_MODE HTML
+
+
+%INPUT
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorate="~{Parent}">
+<head>
+	<title>Page title</title>
+	<script src="child-script.js"></script>
+</head>
+<body>
+	<div layout:fragment="content">
+		<p>Page content</p>
+	</div>
+	<footer layout:fragment="footer">
+	  <p>Page footer</p>
+	</footer>
+</body>
+</html>
+
+
+%INPUT[Parent]
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorate="~{Grandparent}">
+<head>
+	<script src="parent-script.js"></script>
+</head>
+<body>
+	<section layout:fragment="section">
+		<header>
+			<h1>My website</h1>
+		</header>
+		<div layout:fragment="content">
+			<p>Parent content</p>
+		</div>
+	</section>
+	<!-- parent redeclares footer -->
+	<footer layout:fragment="footer">
+		<p>Parent footer</p>
+	</footer>
+</body>
+</html>
+
+
+%INPUT[Grandparent]
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<head>
+	<script src="grandparent-script.js"></script>
+</head>
+<body>
+	<section layout:fragment="section">
+		<p>Grandparent section</p>
+	</section>
+	<footer layout:fragment="footer">
+		<p>Grandparent footer</p>
+	</footer>
+</body>
+</html>
+
+
+%OUTPUT
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Page title</title>
+	<script src="grandparent-script.js"></script>
+	<script src="parent-script.js"></script>
+	<script src="child-script.js"></script>
+</head>
+<body>
+	<section>
+		<header>
+			<h1>My website</h1>
+		</header>
+		<div>
+			<p>Page content</p>
+		</div>
+	</section>
+	<footer>
+		<p>Page footer</p>
+	</footer>
+</body>
+</html>

--- a/tests/nz/net/ultraq/thymeleaf/tests/includes/Include-NestedFragmentInfiniteLoop.thtest
+++ b/tests/nz/net/ultraq/thymeleaf/tests/includes/Include-NestedFragmentInfiniteLoop.thtest
@@ -8,15 +8,10 @@
 %INPUT
 <html>
 <body>
-	<div layout:fragment="comment">
-		Comment structure
-		<div layout:fragment="comment-details">Default comment details</div>
-	</div>
-
-	<div layout:include="~{::comment}">
+	<div layout:include="~{comments :: comment}">
 		<div layout:fragment="comment-details">
 			Top level comment
-			<div layout:include="~{::comment}">
+			<div layout:include="~{comments :: comment}">
 				<div layout:fragment="comment-details">Nested comment</div>
 			</div>
 		</div>
@@ -24,13 +19,15 @@
 </body>
 </html>
 
+%INPUT[comments]
+	<div layout:fragment="comment">
+		Comment structure
+		<div layout:fragment="comment-details">Default comment details</div>
+	</div>
+
 %OUTPUT
 <html>
 <body>
-	<div>
-		Comment structure
-		<div>Default comment details</div>
-	</div>
 	<div>
 		Comment structure
 		<div>

--- a/tests/nz/net/ultraq/thymeleaf/tests/includes/Insert-NestedFragmentInfiniteLoop.thtest
+++ b/tests/nz/net/ultraq/thymeleaf/tests/includes/Insert-NestedFragmentInfiniteLoop.thtest
@@ -8,15 +8,10 @@
 %INPUT
 <html>
 <body>
-	<div layout:fragment="comment">
-		Comment structure
-		<div layout:fragment="comment-details">Default comment details</div>
-	</div>
-
-	<div layout:insert="~{::comment}">
+	<div layout:insert="~{comments :: comment}">
 		<div layout:fragment="comment-details">
 			Top level comment
-			<div layout:insert="~{::comment}">
+			<div layout:insert="~{comments :: comment}">
 				<div layout:fragment="comment-details">Nested comment</div>
 			</div>
 		</div>
@@ -24,13 +19,15 @@
 </body>
 </html>
 
+%INPUT[comments]
+	<div layout:fragment="comment">
+		Comment structure
+		<div layout:fragment="comment-details">Default comment details</div>
+	</div>
+
 %OUTPUT
 <html>
 <body>
-	<div>
-		Comment structure
-		<div>Default comment details</div>
-	</div>
 	<div>
 		<div>
 			Comment structure

--- a/tests/nz/net/ultraq/thymeleaf/tests/includes/Replace-NestedFragmentInfiniteLoop.thtest
+++ b/tests/nz/net/ultraq/thymeleaf/tests/includes/Replace-NestedFragmentInfiniteLoop.thtest
@@ -8,15 +8,10 @@
 %INPUT
 <html>
 <body>
-	<div layout:fragment="comment">
-		Comment structure
-		<div layout:fragment="comment-details">Default comment details</div>
-	</div>
-
-	<div layout:replace="~{::comment}">
+	<div layout:replace="~{comments :: comment}">
 		<div layout:fragment="comment-details">
 			Top level comment
-			<div layout:replace="~{::comment}">
+			<div layout:replace="~{comments :: comment}">
 				<div layout:fragment="comment-details">Nested comment</div>
 			</div>
 		</div>
@@ -24,13 +19,15 @@
 </body>
 </html>
 
+%INPUT[comments]
+	<div layout:fragment="comment">
+		Comment structure
+		<div layout:fragment="comment-details">Default comment details</div>
+	</div>
+
 %OUTPUT
 <html>
 <body>
-	<div>
-		Comment structure
-		<div>Default comment details</div>
-	</div>
 	<div>
 		Comment structure
 		<div>


### PR DESCRIPTION
- also changes the way that top down processing (aka include/replace/insert) and standard processing works in terms of handling the fragments stored in the FragmentMap

- existing InfiniteLoop tests for include/replace/insert have been modified in order to show that they will still work with referenced fragments from external templates. embedding the same fragments in the same template still works